### PR TITLE
feat(logger): When in dev mode, logger outputs more easily readable messages

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -81,18 +81,19 @@ const logger = winston.createLogger({
     silly: 5,
   },
   format: winston.format.printf((info) => {
-    // Print dev-friendly message in development mode.
-    // As an example, for `logger.error('Something bad', { error, processId })`,
-    // this looks like:
-    //
-    // ```
-    // [ERROR] Something bad
-    //
-    // Error: bad thing happened at
-    // {stack trace}
-    //
-    // processId: 123
-    // ```
+    /* Print dev-friendly message in development mode.
+
+    As an example, for `logger.error('Something bad', { error, processId })`,
+    this looks like:
+
+    ```
+    [ERROR] Something bad
+
+    Error: bad thing happened at
+    {stack trace}
+
+    processId: 123
+    ``` */
     if (process.env.NODE_ENV === 'development') {
       const { error, level, message, ...rest } = info;
       let result = `[${level.toUpperCase()}] ${message}`;


### PR DESCRIPTION
## QA

### development mode

```bash
➜  app-utils git:(feature/dev-friendly-logger) NODE_ENV=development node
```

(apologies, I had to wrap the `logger.*` calls in an IIFE, because winston logger calls return this massive `logger` object, which would be printed to the REPL)

```js
> (() => { logger.info('hi'); })()
[INFO] hi
undefined
> (() => { logger.info('hi', { processId: 'abc', date: 123 } ); })()
[INFO] hi

processId: abc
date: 123
undefined
> (() => { logger.error('hi', { processId: 'abc', date: 123, error: new Error('uh oh D:') } ); })()
[ERROR] hi

Error: uh oh D:
    at REPL31:1:67
    at REPL31:1:96
    at Script.runInThisContext (vm.js:132:18)
    at REPLServer.defaultEval (repl.js:484:29)
    at bound (domain.js:430:14)
    at REPLServer.runBound [as eval] (domain.js:443:12)
    at REPLServer.onLine (repl.js:817:10)
    at REPLServer.emit (events.js:327:22)
    at REPLServer.EventEmitter.emit (domain.js:486:12)
    at REPLServer.Interface._onLine (readline.js:337:10)

processId: abc
date: 123
undefined
> 
```

### production mode

```bash
➜  app-utils git:(feature/dev-friendly-logger) NODE_ENV=production node
```

```js
> var { logger } = require('./src/index')
undefined
> (() => { logger.error('hi', { processId: 'abc', date: 123, error: new Error('uh oh D:') } ); })()
{"processId":"abc","date":123,"level":"error","message":"hi","error":{"name":"Error","message":"uh oh D:","stack":"Error: uh oh D:\n    at REPL3:1:67\n    at REPL3:1:96\n    at Script.runInThisContext (vm.js:132:18)\n    at REPLServer.defaultEval (repl.js:484:29)\n    at bound (domain.js:430:14)\n    at REPLServer.runBound [as eval] (domain.js:443:12)\n    at REPLServer.onLine (repl.js:817:10)\n    at REPLServer.emit (events.js:327:22)\n    at REPLServer.EventEmitter.emit (domain.js:486:12)\n    at REPLServer.Interface._onLine (readline.js:337:10)"}}
undefined
> 
```