### PR TITLE
fix(logger): Remove axios error toJSON() function

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,5 @@
+"I want to make a change to @imin/app-utils"
+
+1. Make change(s)
+2. Test/Build with `npm test`
+3. If it passes, ✅

--- a/src/logger.js
+++ b/src/logger.js
@@ -52,6 +52,8 @@ function errorToLoggableObject(error) {
     // state that doesn't need to be logged. We generally just want the URL and method
     delete returnError.request;
     delete returnError.config;
+    // axios errors include a toJSON() function, which reduces the amount of information that they expose
+    delete returnError.toJSON;
     returnError.isAxiosRequestError = true;
     returnError.axiosConfig = axiosErrorConfigToLoggableObject(error);
   }
@@ -61,6 +63,8 @@ function errorToLoggableObject(error) {
     // state that doesn't need to be logged. We generally just want the URL and method
     delete returnError.response;
     delete returnError.config;
+    // axios errors include a toJSON() function, which reduces the amount of information that they expose
+    delete returnError.toJSON;
     returnError.isAxiosResponseError = true;
     returnError.axiosConfig = axiosErrorConfigToLoggableObject(error);
     returnError.axiosResponse = {


### PR DESCRIPTION
As it interferes with error logging

JSON.stringify(..) must defer to a `.toJSON(..)` function if it exists on a particular object - and axios errors have this function, which only renders a tiny amount of info to that JSON object. So here the fix is to just remove it