### PR TITLE
chore: Allow higher NPM versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "engines": {
     "node": ">=14.15.0",
-    "npm": "8.11.0"
+    "npm": ">=8.11.0"
   },
   "dependencies": {
     "@imin/shared-data-types": "github:imin-ltd/shared-data-types#abbb952",


### PR DESCRIPTION
## QA

This NPM limitation was stopping me from being able to use NPM in Checkout (which uses app-utils) as I had a higher NPM version installed

The screenshot shows me trying to use NPM with the current version of app-utils and then with the version from this PR

![Screenshot 2023-02-07 at 13 32 36](https://user-images.githubusercontent.com/2067438/217258813-08f1b6b5-7e7e-4c7b-8abf-dd3278e31851.png)
