### PR TITLE
feat: Option to silence migrations

### DIFF
--- a/built-types/syncDbMigrations.d.ts
+++ b/built-types/syncDbMigrations.d.ts
@@ -20,12 +20,16 @@ export type DbMigrateCmdOptions = {
  * @param {object} [options]
  * @param {PostgresConnectionDetails} [options.postgresConnection] If excluded, defaults to using, from environment vars:
  *   `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_APP_NAME`.
- * @param {boolean} [options.doStartDummyExpressServer] Defaults to `true`
+ * @param {boolean} [options.doStartDummyExpressServer] Defaults to `true`.
+ * @param {boolean} [options.silentMigrations] Defaults to `false`. If `true`, migration logs will not be output.
+ *   This is useful for environments in which a full migration from start to finish is regularly performed, like CI.
+ *   Some projects have thousands and thousands of lines of migrations.
  * @param {DbMigrateCmdOptions} [options.dbMigrateCmdOptions]
  */
 export function syncDbMigrations(options?: {
     postgresConnection?: import("./postgres").PostgresConnectionDetails | undefined;
     doStartDummyExpressServer?: boolean | undefined;
+    silentMigrations?: boolean | undefined;
     dbMigrateCmdOptions?: DbMigrateCmdOptions | undefined;
 } | undefined): Promise<void>;
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@imin/shared-data-types": "github:imin-ltd/shared-data-types#abbb952",
+        "@imin/shared-data-types": "github:imin-ltd/shared-data-types#9eefe1d",
         "@imin/speck": "github:imin-ltd/speck#94b3c55",
         "@types/ramda": "^0.28.15",
         "circular-json": "^0.5.9",
@@ -38,7 +38,7 @@
       },
       "engines": {
         "node": ">=14.15.0",
-        "npm": "8.11.0"
+        "npm": ">=8.11.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -53,14 +53,15 @@
     },
     "node_modules/@imin/shared-data-types": {
       "version": "1.4.0",
-      "resolved": "git+ssh://git@github.com/imin-ltd/shared-data-types.git#abbb952ffd8d97493a32f537a74b459974edb65c",
+      "resolved": "git+ssh://git@github.com/imin-ltd/shared-data-types.git#9eefe1dccb4ef7e5d41dc350b5d73f37ef7fa87c",
       "license": "ISC",
       "dependencies": {
         "@imin/speck": "github:imin-ltd/speck#94b3c55",
         "moment": "~2.24.0"
       },
       "engines": {
-        "node": ">=10.16.0"
+        "node": ">=10.16.0",
+        "npm": ">=7.24.2"
       }
     },
     "node_modules/@imin/shared-data-types/node_modules/moment": {
@@ -2048,8 +2049,8 @@
       }
     },
     "@imin/shared-data-types": {
-      "version": "git+ssh://git@github.com/imin-ltd/shared-data-types.git#abbb952ffd8d97493a32f537a74b459974edb65c",
-      "from": "@imin/shared-data-types@github:imin-ltd/shared-data-types#abbb952",
+      "version": "git+ssh://git@github.com/imin-ltd/shared-data-types.git#9eefe1dccb4ef7e5d41dc350b5d73f37ef7fa87c",
+      "from": "@imin/shared-data-types@github:imin-ltd/shared-data-types#9eefe1d",
       "requires": {
         "@imin/speck": "github:imin-ltd/speck#94b3c55",
         "moment": "~2.24.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": ">=8.11.0"
   },
   "dependencies": {
-    "@imin/shared-data-types": "github:imin-ltd/shared-data-types#abbb952",
+    "@imin/shared-data-types": "github:imin-ltd/shared-data-types#9eefe1d",
     "@imin/speck": "github:imin-ltd/speck#94b3c55",
     "@types/ramda": "^0.28.15",
     "circular-json": "^0.5.9",

--- a/src/syncDbMigrations.js
+++ b/src/syncDbMigrations.js
@@ -22,13 +22,19 @@ const { port } = require('./utils/port');
  * @param {object} [options]
  * @param {PostgresConnectionDetails} [options.postgresConnection] If excluded, defaults to using, from environment vars:
  *   `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_APP_NAME`.
- * @param {boolean} [options.doStartDummyExpressServer] Defaults to `true`
+ * @param {boolean} [options.doStartDummyExpressServer] Defaults to `true`.
+ * @param {boolean} [options.silentMigrations] Defaults to `false`. If `true`, migration logs will not be output.
+ *   This is useful for environments in which a full migration from start to finish is regularly performed, like CI.
+ *   Some projects have thousands and thousands of lines of migrations.
  * @param {DbMigrateCmdOptions} [options.dbMigrateCmdOptions]
  */
 async function syncDbMigrations(options) {
   const doStartDummyExpressServer = options?.doStartDummyExpressServer ?? true;
   logger.info('syncDbMigrations() - syncing..');
   const dbMigrate = await getDbMigrateInstance(options?.postgresConnection, options?.dbMigrateCmdOptions);
+  if (options?.silentMigrations ?? false) {
+    dbMigrate.silence(true);
+  }
   const dummyServer = doStartDummyExpressServer ? await startDummyExpressServer() : null;
   if (dummyServer != null) { await stopDummyExpressServer(dummyServer); }
   await dbMigrate.up();


### PR DESCRIPTION
QA: I have run this on imin Booking API CI (on Agg migrations) and– after some huge amount of fiddling as this feature is actually kinda broken on db-migrate– it works

Powers: https://github.com/imin-ltd/platform-agg/pull/1101