### PR TITLE
feat(logger): Support BigInts and improve error support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ The logger will make sure to structure the Error object correctly, so that it's 
 
 If the error is an **Axios error**, we have more special handling still! Axios errors are famously large and contain lots and lots of generally irrelevant information. So if you include an axios error in the `error` field, logger will only include key details about the HTTP request and response.
 
+### JSON formatting
+
+In [Production mode](#production-mode), logs are outputted as JSON. This uses a slightly modified form of JSON stringification which has the following augmentations:
+
+* Circular JSON is supported (using [CircularJSON](https://github.com/WebReflection/circular-json)).
+* BigInts are converted to strings (rather than erroring).
+* Errors are converted to objects, so that `name`, `message` and `stack` are included in the output.
+
 ## PostgreSQL
 
 You can use `@imin/app-utils` to connect with a PostgreSQL database. In order to do this, it is advised to set up environment variables for PostgreSQL connection details (detailed below), though in some cases, connection details can be provided programmatically.

--- a/README.md
+++ b/README.md
@@ -193,3 +193,7 @@ Example usage:
 > getHerokuReleaseInfo();
 { herokuReleaseVersion: 'v925', herokuSlugCommit: 'bec18bdb698457c8a8e5dbf2828bdeeac4918166' }
 ```
+
+# Contributing
+
+Run `npm run build` before committing (TODO do this automatically).

--- a/built-types/lenses.d.ts
+++ b/built-types/lenses.d.ts
@@ -10,17 +10,17 @@ export type Organizer = import('@imin/shared-data-types/src/modellingSpec/common
 export type OfferType = import('@imin/shared-data-types/src/modellingSpec/common').OfferType;
 export type SearchIsBookingRequestFacilityUseType = import('@imin/shared-data-types/src/search/SearchIsBookingRequestFacilityUseSlot').SearchIsBookingRequestFacilityUseType;
 export namespace Lenses {
-    const seller: import('ramda').Lens<TOpportunity, Organizer>;
-    const providerId: import('ramda').Lens<TOpportunity, string>;
-    const name: import('ramda').Lens<TOpportunity, string>;
-    const place: import('ramda').Lens<TOpportunity, PlaceType>;
-    const facilityUse: import('ramda').Lens<TOpportunity, SearchIsBookingRequestFacilityUseType>;
-    const offers: import('ramda').Lens<TOpportunity, OfferType[]>;
-    const aggregateOffer: R.Lens<TOpportunity, any>;
-    const remainingCapacity: import('ramda').Lens<TOpportunity, number>;
-    const maxCapacity: import('ramda').Lens<TOpportunity, number>;
+    let seller: import('ramda').Lens<TOpportunity, Organizer>;
+    let providerId: import('ramda').Lens<TOpportunity, string>;
+    let name: import('ramda').Lens<TOpportunity, string>;
+    let place: import('ramda').Lens<TOpportunity, PlaceType>;
+    let facilityUse: import('ramda').Lens<TOpportunity, SearchIsBookingRequestFacilityUseType>;
+    let offers: import('ramda').Lens<TOpportunity, OfferType[]>;
+    let aggregateOffer: R.Lens<TOpportunity, any>;
+    let remainingCapacity: import('ramda').Lens<TOpportunity, number>;
+    let maxCapacity: import('ramda').Lens<TOpportunity, number>;
     namespace util {
-        const throwErrorIfUsed: import('ramda').Lens<any, any>;
+        let throwErrorIfUsed: import('ramda').Lens<any, any>;
     }
 }
 import R = require("ramda");

--- a/src/logger.js
+++ b/src/logger.js
@@ -118,9 +118,11 @@ const logger = winston.createLogger({
     const { error, ...rest } = info;
     if (error !== undefined) {
       const loggableError = errorToLoggableObject(error);
-      return CircularJSON.stringify({ ...rest, error: loggableError });
+      return CircularJSON.stringify({ ...rest, error: loggableError }, jsonStringifyReplacerForLogger);
+      // return CircularJSON.stringify({ ...rest, error: loggableError });
     }
-    return CircularJSON.stringify({ ...rest });
+    return CircularJSON.stringify({ ...rest }, jsonStringifyReplacerForLogger);
+    // return CircularJSON.stringify({ ...rest });
   }),
   transports: [
     new winston.transports.Console({
@@ -129,6 +131,23 @@ const logger = winston.createLogger({
     }),
   ],
 });
+
+/**
+ * @param {string} key
+ * @param {unknown} value
+ */
+function jsonStringifyReplacerForLogger(key, value) {
+  /* BigInts cannot be serialized to JSON (why though? JSON has no number size
+  limit. Anyway..). Converting them to strings is acceptable here as they are
+  just being logged. */
+  if (typeof value === 'bigint') {
+    return String(value);
+  }
+  if (value instanceof Error) {
+    return errorToLoggableObject(value);
+  }
+  return value;
+}
 
 module.exports = {
   logger,

--- a/src/logger.js
+++ b/src/logger.js
@@ -119,10 +119,8 @@ const logger = winston.createLogger({
     if (error !== undefined) {
       const loggableError = errorToLoggableObject(error);
       return CircularJSON.stringify({ ...rest, error: loggableError }, jsonStringifyReplacerForLogger);
-      // return CircularJSON.stringify({ ...rest, error: loggableError });
     }
     return CircularJSON.stringify({ ...rest }, jsonStringifyReplacerForLogger);
-    // return CircularJSON.stringify({ ...rest });
   }),
   transports: [
     new winston.transports.Console({


### PR DESCRIPTION
Errors can now be rendered without having to be at .error

## QA

```js
➜  app-utils git:(main) ✗ node
Welcome to Node.js v18.18.0.
Type ".help" for more information.
> var logger = require('./src/index.js').logger;
> void logger.info('hi', {
  some: 'data',
  obj: {
    biggie: 999999999999999912n,
    errrr: new Error('an error oh no')
  },
  error: new Error('error22222')
});

{
  "some": "data",
  "obj": {
    "biggie": "999999999999999912",
    "errrr": {
      "name": "Error",
      "message": "an error oh no",
      "stack": "Error: an error oh no\n    at REPL7:1:83\n    at Script.runInThisContext (node:vm:123:12)\n    at REPLServer.defaultEval (node:repl:569:29)\n    at bound (node:domain:433:15)\n    at REPLServer.runBound [as eval] (node:domain:444:12)\n    at REPLServer.onLine (node:repl:899:10)\n    at REPLServer.emit (node:events:529:35)\n    at REPLServer.emit (node:domain:489:12)\n    at [_onLine] [as _onLine] (node:internal/readline/interface:423:12)\n    at [_line] [as _line] (node:internal/readline/interface:894:18)"
    }
  },
  "level": "info",
  "message": "hi",
  "error": {
    "name": "Error",
    "message": "error22222",
    "stack": "Error: error22222\n    at REPL7:1:121\n    at Script.runInThisContext (node:vm:123:12)\n    at REPLServer.defaultEval (node:repl:569:29)\n    at bound (node:domain:433:15)\n    at REPLServer.runBound [as eval] (node:domain:444:12)\n    at REPLServer.onLine (node:repl:899:10)\n    at REPLServer.emit (node:events:529:35)\n    at REPLServer.emit (node:domain:489:12)\n    at [_onLine] [as _onLine] (node:internal/readline/interface:423:12)\n    at [_line] [as _line] (node:internal/readline/interface:894:18)"
  }
}
```

Here's how that looks in `main`:

```js
> void logger.info('hi', { some: 'data', obj: { biggie: 999999999999999912n, errrr: new Error('an error oh no') }, error: new Error('error22222') } )
Uncaught TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at Object.stringify (/Users/lukewinship/Dev/app-utils/node_modules/circular-json/build/circular-json.node.js:189:32)
```